### PR TITLE
Learning rate decay

### DIFF
--- a/uberduck_ml_dev/trainer/base.py
+++ b/uberduck_ml_dev/trainer/base.py
@@ -51,6 +51,9 @@ class TTSTrainer:
         self.is_validate = hparams.is_validate
         self.num_workers = hparams.num_workers
         self.pin_memory = hparams.pin_memory
+        self.lr_decay_start = hparams.lr_decay_start
+        self.lr_decay_rate = hparams.lr_decay_rate
+        self.lr_decay_min = hparams.lr_decay_min
 
         # NOTE (Sam): these are deprecated.
         self.distributed_run = hparams.distributed_run
@@ -204,6 +207,9 @@ DEFAULTS = HParams(
     distributed_run=False,
     num_workers=1,
     pin_memory=True,
+    lr_decay_start=15000,
+    lr_decay_rate=216000,
+    lr_decay_min=1e-5
 )
 
 config = DEFAULTS.values()

--- a/uberduck_ml_dev/trainer/tacotron2.py
+++ b/uberduck_ml_dev/trainer/tacotron2.py
@@ -4,7 +4,7 @@ from random import randint
 import time
 from typing import List
 from random import choice
-from math import e as EulerNumber
+import numpy as np
 
 import torch
 from torch import nn
@@ -467,7 +467,7 @@ class Tacotron2Trainer(TTSTrainer):
                 
                 # Learning Rate decay, can be disabled if lr_decay_start is == 0 or None
                 if (self.global_step > self.lr_decay_start) and (self.lr_decay_start not in [0, None]):
-                    learning_rate = (self.learning_rate * (EulerNumber ** (-self.global_step / self.lr_decay_rate)))
+                    learning_rate = (self.learning_rate * (np.exp(-self.global_step / self.lr_decay_rate)))
                     learning_rate = max(self.lr_decay_min, learning_rate)
                     self.learning_rate = learning_rate
                     for param_group in optimizer.param_groups:


### PR DESCRIPTION
Adds learning rate decay to trainer/Tacotron2.py

![](https://media.discordapp.net/attachments/859584739677700106/1039397055291990036/image.png)

New default hparams:

lr_decay_start=15000, # The global step to start decay
lr_decay_rate=216000, # Rate which to decay. 
Equation: `learning_rate = (self.learning_rate * (EulerNumber ** (-self.global_step / self.lr_decay_rate)))`
lr_decay_min=1e-5 # Minimum LR