### PR TITLE
Unify forward passes in models.tacotron and fix speaker encoder edge case

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain # ruamel.yaml==0.15.87
+requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.13.0 torchaudio==0.13.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain ruamel.yaml==0.15.87 # ruamel.yaml==0.16.12
+requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain # ruamel.yaml==0.15.87
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
+requirements = Cython pytest wget phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit
+requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.13.0 torchaudio==0.13.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain ruamel.yaml==0.15.87 # ruamel.yaml==0.16.12
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =

--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest wget phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
+requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ import os
 import tempfile
 
 import torch
-import wget
+
+import requests
 
 from uberduck_ml_dev.models.tacotron2 import DEFAULTS as TACOTRON2_DEFAULTS
 from uberduck_ml_dev.models.tacotron2 import Tacotron2
@@ -26,10 +27,14 @@ def _load_tacotron_uninitialized(overrides=None):
 @pytest.fixture(scope="session")
 def lj_speech_tacotron2_file():
     tf = tempfile.NamedTemporaryFile(suffix=".pt")
-    tf.close()
+    # tf.close()
     # NOTE (Sam): A canonical LJ statedict used in our warm starting notebook.
     url_ = "https://uberduck-demo.s3.us-west-2.amazonaws.com/tacotron2_statedict_lj_test.pt"
-    wget.download(url_, out=tf.name)
+    res = requests.get(url_)
+    if res.status_code == 200:  # http 200 means success
+        with open(tf.name, "wb") as file_handle:  # wb means Write Binary
+            file_handle.write(res.content)
+
     return tf
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,10 @@
 import torch
-import tempfile
 import pytest
 import os
+import tempfile
 
-import gdown
-from scipy.io import wavfile
-import numpy as np
 import torch
+import wget
 
 from uberduck_ml_dev.models.tacotron2 import DEFAULTS as TACOTRON2_DEFAULTS
 from uberduck_ml_dev.models.tacotron2 import Tacotron2
@@ -27,11 +25,12 @@ def _load_tacotron_uninitialized(overrides=None):
 
 @pytest.fixture(scope="session")
 def lj_speech_tacotron2_file():
+    tf = tempfile.NamedTemporaryFile(suffix=".pt")
+    tf.close()
     # NOTE (Sam): A canonical LJ statedict used in our warm starting notebook.
-    url = "https://drive.google.com/uc?id=1qgEwtL53oFsdllM14FRZncgnARnAGInO"
-    output_file = tempfile.NamedTemporaryFile()
-    gdown.download(url, output_file.name, quiet=False)
-    return output_file
+    url_ = "https://uberduck-demo.s3.us-west-2.amazonaws.com/tacotron2_statedict_lj_test.pt"
+    wget.download(url_, out=tf.name)
+    return tf
 
 
 @pytest.fixture

--- a/uberduck_ml_dev/models/tacotron2.py
+++ b/uberduck_ml_dev/models/tacotron2.py
@@ -130,13 +130,9 @@ class Tacotron2(TTSModel):
         if self.n_speakers > 1 and not self.has_speaker_embedding:
             raise Exception("Speaker embedding is required if n_speakers > 1")
         if hparams.has_speaker_embedding:
-            if self.new_speaker_embedding:
-                self.speaker_embedding = nn.Embedding(
-                    self.n_speakers, hparams.speaker_embedding_dim
-                )
-            # NOTE (Sam): treating context encoders generically will remove such code.
-            if self.speechbrain_speaker_embedding:
-                self.speaker_embedding = self.mean_embedding_function()
+            self.speaker_embedding = nn.Embedding(
+                self.n_speakers, hparams.speaker_embedding_dim
+            )
         else:
             self.speaker_embedding = None
 

--- a/uberduck_ml_dev/models/tacotron2.py
+++ b/uberduck_ml_dev/models/tacotron2.py
@@ -201,11 +201,8 @@ class Tacotron2(TTSModel):
         encoder_outputs = embedded_text
         # NOTE (Sam): in a previous version, has_speaker_embedding was implicitly set to be false for n_speakers = 1.
         if self.has_speaker_embedding is True:
-            if self.has_audio_embedding is True:
-                embedded_speakers += self.audio_lin(audio_encoding)
-            else:
-                embedded_speakers = self.speaker_embedding(speaker_ids)[:, None]
-                encoder_outputs += self.spkr_lin(embedded_speakers)
+            embedded_speakers = self.speaker_embedding(speaker_ids)[:, None]
+            encoder_outputs += self.spkr_lin(embedded_speakers)
 
         if self.with_gst:
             assert (

--- a/uberduck_ml_dev/models/tacotron2.py
+++ b/uberduck_ml_dev/models/tacotron2.py
@@ -134,13 +134,11 @@ class Tacotron2(TTSModel):
         else:
             self.speaker_embedding = None
 
-        # NOTE (Sam): Why does the zero network alter results (see below)?
         if self.has_speaker_embedding:
+            #   NOTE (Sam): self.spkr_lin = ZeroNetwork() if n_speakers == 1 gives fewer trainable terms, and could potentially be better for fine tuning, although we don't really know.
             self.spkr_lin = nn.Linear(
                 self.speaker_embedding_dim, self.encoder_embedding_dim
             )
-        else:
-            self.spkr_lin = ZeroNetwork()
 
         self.gst_init(hparams)
 
@@ -190,9 +188,9 @@ class Tacotron2(TTSModel):
         mel_stop_index: Optional[int] = 0,
     ):
 
-        if input_lengths:
+        if input_lengths is not None:
             input_lengths = input_lengths.data
-        if output_lengths:
+        if output_lengths is not None:
             output_lengths = output_lengths.data
 
         embedded_inputs = self.embedding(input_text).transpose(1, 2)

--- a/uberduck_ml_dev/models/torchmoji.py
+++ b/uberduck_ml_dev/models/torchmoji.py
@@ -1,3 +1,4 @@
+# TODO (Sam): move to encoders
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 

--- a/uberduck_ml_dev/trainer/tacotron2.py
+++ b/uberduck_ml_dev/trainer/tacotron2.py
@@ -22,7 +22,7 @@ from ..monitoring.statistics import get_alignment_metrics
 from ..data.batch import Batch
 from ..vendor.tfcompat.hparam import HParams
 from .base import DEFAULTS as TRAINER_DEFAULTS
-from ..models.tacotron2 import DEFAULTS as TACOTRON2_DEFAULTS
+from ..models.tacotron2 import DEFAULTS as TACOTRON2_DEFAULTS, INFERENCE
 from ..models.torchmoji import TorchMojiInterface
 from ..utils.plot import (
     plot_attention,
@@ -269,11 +269,12 @@ class Tacotron2Trainer(TTSTrainer):
 
             model.eval()
 
-            sample_inference = model.inference(
+            sample_inference = model.forward(
                 input_text=utterance,
                 input_lengths=input_lengths,
                 speaker_ids=speaker_id_tensor,
                 embedded_gst=gst_embedding,
+                mode=INFERENCE,
             )
             model.train()
             try:

--- a/uberduck_ml_dev/trainer/tacotron2.py
+++ b/uberduck_ml_dev/trainer/tacotron2.py
@@ -110,17 +110,11 @@ class Tacotron2Trainer(TTSTrainer):
                 self.hparams.get("torchmoji_vocabulary_file"),
                 self.hparams.get("torchmoji_model_file"),
             )
-            # NOTE (Sam): rename gst to gsts[0]
+            # TODO (Sam): rename gst to gsts[0]
             self.compute_gst = lambda texts: self.torchmoji.encode_texts(texts)
         else:
             self.compute_gst = None
 
-        # NOTE (Sam): some ambiguity in naming between audio_encoder and speaker_encoder
-        # Speaker_encoder is really mean audio_encoder
-        if self.hparams.get("audio_encoder") == "spkrec-ecapa-voxceleb":
-            from speechbrain.pretrained import EncoderClassifier
-            self.audio_encoder = EncoderClassifier.from_hparams(self.hparams.get("speechbrain/spkrec-ecapa-voxceleb"))
-            self.compute_audio_encoding =
         if not self.sample_inference_speaker_ids:
             self.sample_inference_speaker_ids = list(range(self.n_speakers))
 

--- a/uberduck_ml_dev/trainer/tacotron2.py
+++ b/uberduck_ml_dev/trainer/tacotron2.py
@@ -96,7 +96,7 @@ class Tacotron2Trainer(TTSTrainer):
         self.lr_decay_rate = self.hparams.lr_decay_rate
         self.lr_decay_min = self.hparams.lr_decay_min
 
-        # NOTE (Sam): its not clear we should lambdafy models here rather than the data_loader or some other helper function
+        # NOTE (Sam): its not clear we should lambdafy models here rather than the data_loader or some other helper function.
         if self.hparams.get("gst_type") == "torchmoji":
             assert self.hparams.get(
                 "torchmoji_vocabulary_file"
@@ -110,7 +110,7 @@ class Tacotron2Trainer(TTSTrainer):
                 self.hparams.get("torchmoji_vocabulary_file"),
                 self.hparams.get("torchmoji_model_file"),
             )
-            # TODO (Sam): rename gst to gsts[0]
+            # TODO (Sam): rename gst to gsts[0].
             self.compute_gst = lambda texts: self.torchmoji.encode_texts(texts)
         else:
             self.compute_gst = None


### PR DESCRIPTION
Combine forward pass methods in Tacotron to simplify code.  Still need to simplify decoder methods.

Also removes edge case when n_speakers = 1 and has_speaker_embedding = True.