### PR TITLE
Replace deprecated `sklearn` alias

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
-requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy sklearn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
+requirements = Cython pytest phonemizer inflect librosa matplotlib nltk>=3.6.5 numpy>=1.20 csvw clldutils pandas pydub scipy scikit-learn soundfile tensorboardX torch==1.9.0 torchaudio==0.9.0 unidecode seaborn mdutils wordcloud wordfreq Pillow einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode gdown pre-commit hyperpyyaml@git+https://github.com/sjkoelle/HyperPyYAML speechbrain@git+https://github.com/sjkoelle/speechbrain 
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =


### PR DESCRIPTION
The package `sklearn` used to silently install `scikit-learn`, but as it's being deprecated, it has begun applying a "[brownout strategy](https://pypi.org/project/sklearn/)" that intentionally throws exceptions during randomly selected installs.