### PR TITLE
use public g2p package instead of private uberduck

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -27,7 +27,7 @@ status = 2
 # Optional. Same format as setuptools requirements.  Torch version seems to effect random number generator (not 100% certain).
 # TODO (Sam): our goal is to rely on as few 3rd party packages as possible.  We should try to remove as many of these as possible and integrate torch code directly.
 # NOTE (Sam): is it possible to specify no-deps here?
-requirements = Cython pytest phonemizer inflect librosa>=0.8.0 matplotlib nltk>=3.6.5 numpy>=1.23.5 pandas pydub scipy scikit-learn tensorboardX torch>=1.13.0 torchaudio>=0.9.0 unidecode seaborn wordfreq einops g2p_en@git+https://github.com/uberduck-ai/g2p emoji text-unidecode pre-commit lmdb ray[default] praat-parselmouth>=0.4.3 torchcrepe==0.0.22 pyworld==0.3.2 faiss-cpu==1.7.4
+requirements = Cython pytest phonemizer inflect librosa>=0.8.0 matplotlib nltk>=3.6.5 numpy>=1.23.5 pandas pydub scipy scikit-learn tensorboardX torch>=1.13.0 torchaudio>=0.9.0 unidecode seaborn wordfreq einops g2p_en emoji text-unidecode pre-commit lmdb ray[default] praat-parselmouth>=0.4.3 torchcrepe==0.0.22 pyworld==0.3.2 faiss-cpu==1.7.4
 
 # Optional. Same format as setuptools console_scripts
 # console_scripts =


### PR DESCRIPTION
Instead of using uberduck's `g2p_en` package, we can use the normal `g2p_en` package from pip. This removes the uberduck g2p_en as a dependency, which was confusing dependabot in the uberduck monorepo. 